### PR TITLE
Look for .perltidyrc in file and project folder

### DIFF
--- a/src/beautifiers/perltidy.coffee
+++ b/src/beautifiers/perltidy.coffee
@@ -3,6 +3,7 @@ Requires [perltidy](http://perltidy.sourceforge.net)
 ###
 "use strict"
 Beautifier = require('./beautifier')
+path = require('path')
 
 module.exports = class PerlTidy extends Beautifier
   name: "Perltidy"
@@ -20,7 +21,16 @@ module.exports = class PerlTidy extends Beautifier
     else
       return options.perltidy_path
 
-  beautify: (text, language, options) ->
+  configFiles = ['.perltidyrc']
+  beautify: (text, language, options, context) ->
+        # Find a config file in the working directory if a custom one was not provided
+        if not options.perltidy_profile
+          options.perltidy_profile = if context? and context.filePath? then @findFile(path.dirname(context.filePath), configFiles)
+
+        # Try again to find a config file in the project root
+        if not options.perltidy_profile
+          options.perltidy_profile = @findFile(atom.project.getPaths()[0], configFiles)
+          
     @run("perltidy", [
       '--standard-output'
       '--standard-error-output'

--- a/src/beautifiers/perltidy.coffee
+++ b/src/beautifiers/perltidy.coffee
@@ -23,14 +23,14 @@ module.exports = class PerlTidy extends Beautifier
 
   configFiles = ['.perltidyrc']
   beautify: (text, language, options, context) ->
-        # Find a config file in the working directory if a custom one was not provided
-        if not options.perltidy_profile
-          options.perltidy_profile = if context? and context.filePath? then @findFile(path.dirname(context.filePath), configFiles)
+    # Find a config file in the working directory if a custom one was not provided
+    if not options.perltidy_profile
+      options.perltidy_profile = if context? and context.filePath? then @findFile(path.dirname(context.filePath), configFiles)
 
-        # Try again to find a config file in the project root
-        if not options.perltidy_profile
-          options.perltidy_profile = @findFile(atom.project.getPaths()[0], configFiles)
-          
+    # Try again to find a config file in the project root
+    if not options.perltidy_profile
+      options.perltidy_profile = @findFile(atom.project.getPaths()[0], configFiles)
+
     @run("perltidy", [
       '--standard-output'
       '--standard-error-output'


### PR DESCRIPTION
If options.perltidy_profile is not set, search for .perltidyrc in file path and then in project folder.

### What does this implement/fix? Explain your changes.
Trying to find a perltidy profile file at file and project location.
...

### Does this close any currently open issues?
no
...

### Any other comments?

...

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch
- [ ] Regenerate documentation with `npm run docs`
- [ ] Add change details to `CHANGELOG.md` under "Next" section
- [ ] Added examples for testing to [examples/ directory](examples/)
- [ ] Travis CI passes (Mac support)
- [ ] AppVeyor passes (Windows support)
